### PR TITLE
Right alignment of search box and columns menu

### DIFF
--- a/vendor/assets/stylesheets/bootstrap-table.css
+++ b/vendor/assets/stylesheets/bootstrap-table.css
@@ -191,7 +191,9 @@
     font-weight: normal;
     line-height: 1.428571429;
 }
-
+.fixed-table-toolbar .pull-right{
+    float: right !important;
+}
 .fixed-table-toolbar .bars,
 .fixed-table-toolbar .search,
 .fixed-table-toolbar .columns {


### PR DESCRIPTION
pull-right wasn't working as intended. Suggested change will make search box and columns menu on right side of toolbar same as original bootstrap-table.